### PR TITLE
add workaround for channeled casts not being shown

### DIFF
--- a/LunaUnitFrames.lua
+++ b/LunaUnitFrames.lua
@@ -1,7 +1,7 @@
 -- Luna Unit Frames 4.0 by Aviana
 
 LUF = select(2, ...)
-LUF.version = 4381
+LUF.version = 4382
 
 local L = LUF.L
 local ACR = LibStub("AceConfigRegistry-3.0", true)

--- a/LunaUnitFrames.toc
+++ b/LunaUnitFrames.toc
@@ -2,7 +2,7 @@
 ## Title: Luna Unit Frames
 ## Notes: 
 ## Author: Aviana
-## Version: 4381
+## Version: 4382
 
 ## SavedVariables: LunaUFDB
 ## OptionalDeps: Ace3, LibSharedMedia-3.0, AceGUI-3.0-SharedMediaWidgets, Clique

--- a/libs/oUF_Plugins/oUF_CastBar/oUF_SpellData.lua
+++ b/libs/oUF_Plugins/oUF_CastBar/oUF_SpellData.lua
@@ -161,6 +161,57 @@ oUF.uninterruptibleList = {
     [GetSpellInfo(28783)] = true, -- Impale
 }
 
+
+-- UnitChannelInfo() currently doesn't work in Classic Era 1.15.0 due to a Blizzard bug(?)
+-- We use this data to retrieve spell cast time
+oUF.channeledSpells = {
+    -- MISC
+    [GetSpellInfo(746)] = 8000,      -- First Aid
+    [GetSpellInfo(13278)] = 4000,    -- Gnomish Death Ray
+    [GetSpellInfo(20577)] = 10000,   -- Cannibalize
+    [GetSpellInfo(10797)] = 6000,    -- Starshards
+    [GetSpellInfo(16430)] = 12000,   -- Soul Tap
+    [GetSpellInfo(24323)] = 8000,    -- Blood Siphon
+    [GetSpellInfo(27640)] = 3000,    -- Baron Rivendare's Soul Drain
+    [GetSpellInfo(7290)] = 10000,    -- Soul Siphon
+    [GetSpellInfo(24322)] = 8000,    -- Blood Siphon
+    [GetSpellInfo(27177)] = 10000,   -- Defile
+    [GetSpellInfo(27286)] = 1000,    -- Shadow Wrath (see issue #59)
+    [GetSpellInfo(433797)] = 7000,   -- Bladestorm
+    -- DRUID
+    [GetSpellInfo(17401)] = 10000,   -- Hurricane
+    [GetSpellInfo(740)] = 10000,     -- Tranquility
+    [GetSpellInfo(20687)] = 10000,   -- Starfall
+    -- HUNTER
+    [GetSpellInfo(6197)] = 60000,     -- Eagle Eye
+    [GetSpellInfo(1002)] = 60000,     -- Eyes of the Beast
+    [GetSpellInfo(1510)] = 6000,      -- Volley
+    [GetSpellInfo(136)] = 5000,       -- Mend Pet
+    -- MAGE
+    [GetSpellInfo(5143)] = 5000,      -- Arcane Missiles
+    [GetSpellInfo(7268)] = 3000,      -- Arcane Missile
+    [GetSpellInfo(10)] = 8000,        -- Blizzard
+    [GetSpellInfo(12051)] = 8000,     -- Evocation
+    [GetSpellInfo(401417)] = 3000,    -- Regeneration
+    [GetSpellInfo(412510)] = 3000,    -- Mass Regeneration
+    -- PRIEST
+    [GetSpellInfo(15407)] = 3000,     -- Mind Flay
+    [GetSpellInfo(2096)] = 60000,     -- Mind Vision
+    [GetSpellInfo(605)] = 3000,       -- Mind Control
+    [GetSpellInfo(402174)] = 2000,    -- Penance
+    -- WARLOCK
+    [GetSpellInfo(126)] = 45000,      -- Eye of Kilrogg
+    [GetSpellInfo(689)] = 5000,       -- Drain Life
+    [GetSpellInfo(5138)] = 5000,      -- Drain Mana
+    [GetSpellInfo(1120)] = 15000,     -- Drain Soul
+    [GetSpellInfo(5740)] = 8000,      -- Rain of Fire
+    [GetSpellInfo(1949)] = 15000,     -- Hellfire
+    [GetSpellInfo(755)] = 10000,      -- Health Funnel
+    [GetSpellInfo(17854)] = 10000,    -- Consume Shadows
+    [GetSpellInfo(6358)] = 15000,     -- Seduction Channel
+}
+
+
 if CLIENT_IS_CLASSIC_ERA then
     oUF.uninterruptibleList[GetSpellInfo(2480)] = true -- Shoot Bow
     oUF.uninterruptibleList[GetSpellInfo(7918)] = true -- Shoot Gun

--- a/libs/oUF_Plugins/oUF_TagsWithHeal/oUF_TagsWithHeal.lua
+++ b/libs/oUF_Plugins/oUF_TagsWithHeal/oUF_TagsWithHeal.lua
@@ -193,7 +193,9 @@ local _ENV = {
 	GetHealTimeFrame = function() return oUF.TagsWithHealTimeFrame or 4 end,
 	GetShowHots = function() if oUF.TagsWithHealDisableHots then return LHC.DIRECT_HEALS else return LHC.ALL_HEALS end end,
 	WA_Utf8Sub = WA_Utf8Sub,
-	InCombatLockdownRestriction = InCombatLockdownRestriction
+	InCombatLockdownRestriction = InCombatLockdownRestriction,
+	lastChannelSpellName = function() return oUF.lastChannelSpellName end,
+	lastChannelEndTime = function() return oUF.lastChannelSpellEndTime end,
 }
 _ENV.ColorGradient = function(...)
 	return _ENV._FRAME:ColorGradient(...)
@@ -1200,6 +1202,9 @@ local tagStrings = {
 		if(not name) then
 			name, _, _, _, _, _, notInterruptible = UnitChannelInfo(unit)
 		end
+		if(not name) then 
+			name = lastChannelSpellName()
+		end
 		if(name and notInterruptible) then
 			local c = LUF.db.profile.colors.castnotinterruptibletext
 			local color = Hex(c.r, c.g, c.b)
@@ -1215,6 +1220,8 @@ local tagStrings = {
 			name, _, _, _, endTime = UnitChannelInfo(unit)
 			if name then
 				result = (endTime / 1000) - GetTime()
+			elseif lastChannelSpellName() then
+				result = (lastChannelEndTime() / 1000) - GetTime()
 			end
 		else
 			result = (GetTime() - (endTime / 1000)) * -1
@@ -1232,6 +1239,8 @@ local tagStrings = {
 			name, _, _, _, endTime = UnitChannelInfo(unit)
 			if name then
 				new_time = (endTime / 1000) - GetTime()
+			elseif lastChannelSpellName() then
+				new_time = (lastChannelEndTime() / 1000) - GetTime()
 			end
 		else
 			new_time = (GetTime() - (endTime / 1000)) * -1
@@ -1528,8 +1537,6 @@ onUpdateDelay["cnumtargeting"] = 0.5
 onUpdateDelay["afktime"] = 0.5
 onUpdateDelay["casttime"] = 0.1
 
---since 1.15.0 cast events are not properly triggering so update name automatically
-onUpdateDelay["castname"] = 0.1
 
 local escapeSequences = {
 	["||c"] = "|c",


### PR DESCRIPTION
add workaround for channeled casts not being shown due to a Blizzard bug with UnitChannelInfo()