### PR TITLE
Add support for SuperWow

### DIFF
--- a/LunaUnitFrames.lua
+++ b/LunaUnitFrames.lua
@@ -2,7 +2,8 @@ LunaUF = AceLibrary("AceAddon-2.0"):new("AceEvent-2.0", "AceConsole-2.0", "AceDB
 LunaUF:RegisterDB("LunaDB")
 
 -- Assets ----------------------------------------------------------------------------------
-LunaUF.Version = 2225
+LunaUF.Version = 2226
+LunaUF.isSuperWoW = SUPERWOW_STRING and SUPERWOW_VERSION
 LunaUF.BS = AceLibrary("Babble-Spell-2.2")
 LunaUF.Banzai = AceLibrary("Banzai-1.0")
 LunaUF.HealComm = AceLibrary("HealComm-1.0")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # LunaUnitFrames
 Unit Frames for WoW 1.12.1
 
+Latest vanilla 1.12.1 release (2226+) has support for [SuperWoW](https://github.com/balakethelock/SuperWoW)
+ - Proper cast bars per unit
+ - Better Range check
+ - Still works without superwow
+
+[How to install SuperWoW](https://github.com/pepopo978/SuperwowInstallation)
 
 Feel free to fork this but give credit (at least author & link to this github)
 

--- a/libs/Babble-Zone-2.2/Babble-Zone-2.2.lua
+++ b/libs/Babble-Zone-2.2/Babble-Zone-2.2.lua
@@ -171,6 +171,14 @@ BabbleZone:RegisterTranslations("enUS", function()
 		["Karazhan"] = true,
 		["Caverns of Time"] = true,
 		["Zul'Aman"] = true,
+
+		-- Turtle WoW
+		["Amani'Alor"] = true,
+		["Tel'Abim"] = true,
+		["Alah'thalas"] = true,
+		["Lapidis Isle"] = true,
+		["Gillijim's Isle"] = true,
+		["Scarlet Enclave"] = true,
 	}
 end)
 

--- a/modules/Options.lua
+++ b/modules/Options.lua
@@ -968,24 +968,31 @@ function LunaUF:CreateOptionsMenu()
 	LunaOptionsFrame.icon:SetPoint("TOPLEFT", LunaOptionsFrame, "TOPLEFT", 0, 0)
 
 	LunaOptionsFrame.name = LunaOptionsFrame:CreateFontString(nil, "OVERLAY", "NumberFontNormalHuge")
-	LunaOptionsFrame.name:SetPoint("TOP", LunaOptionsFrame, "TOP", 0, -10)
+	LunaOptionsFrame.name:SetPoint("TOP", LunaOptionsFrame, "TOP", -25, -10)
 	LunaOptionsFrame.name:SetShadowColor(0, 0, 0)
 	LunaOptionsFrame.name:SetShadowOffset(0.8, -0.8)
 	LunaOptionsFrame.name:SetTextColor(1,1,1)
 	LunaOptionsFrame.name:SetText("LUNA UNIT FRAMES")
 
 	LunaOptionsFrame.version = LunaOptionsFrame:CreateFontString(nil, "OVERLAY", "NumberFontNormal")
-	LunaOptionsFrame.version:SetPoint("BOTTOMLEFT", LunaOptionsFrame.name, "BOTTOMRIGHT", 10, 5)
+	LunaOptionsFrame.version:SetPoint("BOTTOMLEFT", LunaOptionsFrame.name, "BOTTOMRIGHT", 0, 5)
 	LunaOptionsFrame.version:SetShadowColor(0, 0, 0)
 	LunaOptionsFrame.version:SetShadowOffset(0.8, -0.8)
 
+	local LunaVersionText = "V."..LunaUF.Version
+	if LunaUF.isSuperWoW then
+		LunaVersionText = LunaVersionText.." SuperWoW "..SUPERWOW_VERSION
+	end
+	
 	if LunaUF.db.profile.version or 0 > LunaUF.Version then
 		LunaOptionsFrame.version:SetTextColor(1,0,0)
-		LunaOptionsFrame.version:SetText("V."..LunaUF.Version.." (Outdated)")
+		LunaVersionText = LunaVersionText.."(Outdated)"
+	elseif LunaUF.isSuperWoW then
+		LunaOptionsFrame.version:SetTextColor(1,0,1)
 	else
 		LunaOptionsFrame.version:SetTextColor(1,1,1)
-		LunaOptionsFrame.version:SetText("V."..LunaUF.Version)
 	end
+	LunaOptionsFrame.version:SetText(LunaVersionText)
 
 	LunaOptionsFrame.help = CreateFrame("Button", nil, LunaOptionsFrame)
 	LunaOptionsFrame.help:SetHeight(14)

--- a/modules/cast.lua
+++ b/modules/cast.lua
@@ -651,7 +651,7 @@ local function OnUnitCastEvent()
 		if not CasterDB[guid] then CasterDB[guid] = {} end
 		CasterDB[guid].sp = spell
 		--CasterDB[guid].rank = nil
-		CasterDB[guid].start = GetTime()
+		CasterDB[guid].start = start
 		CasterDB[guid].ct = timer
 		CasterDB[guid].icon = icon
 

--- a/modules/cast.lua
+++ b/modules/cast.lua
@@ -604,6 +604,70 @@ local function isBuffed()
 	end
 end
 
+
+--SuperWoW Custom cast event
+local function OnUnitCastEvent()
+	if arg3 == "START" or arg3 == "CAST" or arg3 == "CHANNEL" then
+		-- human readable argument list
+		local guid = arg1
+		local target = arg2
+		local event_type = arg3
+		local spell_id = arg4
+		local timer = arg5 / 1000
+		local start = GetTime()
+			
+		--skip instant spells
+		if timer < 0.1 then 
+			if CasterDB[guid] then
+				CasterDB[guid] = nil
+			end
+			return
+		end
+
+		-- get spell info from spell id
+		local spell, icon, _
+		if SpellInfo and SpellInfo(spell_id) then
+			spell, _, icon = SpellInfo(spell_id)
+		end
+
+		-- add cast action to the database
+		if not CasterDB[guid] then CasterDB[guid] = {} end
+		CasterDB[guid].sp = spell
+		--CasterDB[guid].rank = nil
+		CasterDB[guid].start = GetTime()
+		CasterDB[guid].ct = timer
+		CasterDB[guid].icon = icon
+		
+		for _,frame in pairs(LunaUF.Units.frameList) do
+			local _, frame_guid = UnitExists(frame.unit)
+			if frame.unit and frame.castBar and LunaUF.db.profile.units[frame.unitGroup].castBar.enabled and frame_guid == guid then
+				frame.castBar.channeling = event_type == "CHANNEL"
+				Cast:FullUpdate(frame)
+			end
+		end
+
+	elseif arg3 == "FAIL" then
+		local guid = arg1
+
+		if CasterDB[guid] and CasterDB[guid].sp then
+			--set cast time to nil so frame update removes castbar
+			CasterDB[guid].ct = nil
+			for _,frame in pairs(LunaUF.Units.frameList) do
+				local _, frame_guid = UnitExists(frame.unit)
+				if frame.unit and frame.castBar and LunaUF.db.profile.units[frame.unitGroup].castBar.enabled and frame_guid == guid then
+					Cast:FullUpdate(frame)
+				end
+			end
+
+			-- delete all cast entries of guid
+			if CasterDB[guid] then CasterDB[guid] = nil end
+		end
+		
+	
+    end
+		
+end
+
 local function OnEvent()
 	local frame = this:GetParent()
 	if event == "SPELLCAST_CHANNEL_START" then
@@ -864,6 +928,15 @@ function Cast:FullUpdate(frame)
 				end
 			end
 		else
+			
+			--SUPERWOW provides guid casters that we just replace for unit
+			if SUPERWOW_STRING and SUPERWOW_VERSION then
+				local _, guid = UnitExists(frame.unit)
+				if CasterDB[guid] then
+					unitname = guid
+				end
+			end	
+			
 			frame.castBar:SetScript("OnEvent", nil)
 			if CasterDB[unitname] and CasterDB[unitname].ct and (CasterDB[unitname].start + CasterDB[unitname].ct) > GetTime() then
 				frame.castBar.bar:SetMinMaxValues(0, CasterDB[unitname].ct)
@@ -875,7 +948,7 @@ function Cast:FullUpdate(frame)
 				end
 				frame.castBar.Text:SetText(CasterDB[unitname].sp)
 				if LunaUF.db.profile.units[frame.unitGroup].castBar.icon then
-					frame.castBar.icon:SetTexture(BS:GetSpellIcon(CasterDB[unitname].sp) or GetItemIconTexture(CasterDB[unitname].sp))
+					frame.castBar.icon:SetTexture(CasterDB[unitname].icon or BS:GetSpellIcon(CasterDB[unitname].sp) or GetItemIconTexture(CasterDB[unitname].sp))
 				end
 				frame.castBar.casting = true
 				frame.castBar:SetScript("OnUpdate", OnUpdateOther)
@@ -922,20 +995,26 @@ function Cast:MINIMAP_ZONE_CHANGED()
 	end
 end
 
-Cast:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE")
-Cast:RegisterEvent("CHAT_MSG_SPELL_FRIENDLYPLAYER_BUFF")
-Cast:RegisterEvent("CHAT_MSG_SPELL_HOSTILEPLAYER_BUFF")
-Cast:RegisterEvent("CHAT_MSG_SPELL_SELF_DAMAGE")
-Cast:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_CREATURE_DAMAGE")
-Cast:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_HOSTILEPLAYER_BUFFS")
-Cast:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_BUFFS")
-Cast:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_HOSTILEPLAYER_DAMAGE")
-Cast:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE")
-Cast:RegisterEvent("CHAT_MSG_SPELL_PARTY_BUFF")
-Cast:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE")
-Cast:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_PARTY_BUFFS")
-Cast:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_SELF_BUFF")
-Cast:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_PARTY_BUFF")
-Cast:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_BUFF")
-Cast:MINIMAP_ZONE_CHANGED()
-Cast:SetScript("OnEvent", function() this[event](this, arg1) end)
+if SUPERWOW_STRING and SUPERWOW_VERSION then
+	Cast:SetScript("OnEvent", OnUnitCastEvent)
+	Cast:RegisterEvent("UNIT_CASTEVENT")
+else
+	Cast:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE")
+	Cast:RegisterEvent("CHAT_MSG_SPELL_FRIENDLYPLAYER_BUFF")
+	Cast:RegisterEvent("CHAT_MSG_SPELL_HOSTILEPLAYER_BUFF")
+	Cast:RegisterEvent("CHAT_MSG_SPELL_SELF_DAMAGE")
+	Cast:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_CREATURE_DAMAGE")
+	Cast:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_HOSTILEPLAYER_BUFFS")
+	Cast:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_BUFFS")
+	Cast:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_HOSTILEPLAYER_DAMAGE")
+	Cast:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE")
+	Cast:RegisterEvent("CHAT_MSG_SPELL_PARTY_BUFF")
+	Cast:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE")
+	Cast:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_PARTY_BUFFS")
+	Cast:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_SELF_BUFF")
+	Cast:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_PARTY_BUFF")
+	Cast:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_BUFF")
+	Cast:MINIMAP_ZONE_CHANGED()
+	Cast:SetScript("OnEvent", function() this[event](this, arg1) end)
+end
+

--- a/modules/range.lua
+++ b/modules/range.lua
@@ -7,131 +7,8 @@ local BZ = AceLibrary("Babble-Zone-2.2")
 local ScanTip = LunaUF.ScanTip
 local rosterLib = AceLibrary("RosterLib-2.0")
 LunaUF:RegisterModule(Range, "range", L["Range"])
-local Continent,Zone,ZoneName
 local roster = {}
-local ZoneWatch = CreateFrame("Frame")
 local _, playerClass = UnitClass("player")
-
--- Big thx to Renew & Astrolabe
-local MapScales = {
-	[0] = {[0] = {x = 29688.932932224,	y = 44537.340058402}}, -- World Map
-
-	[-1] = { -- Battlegrounds
-		[0] = {x=0.0000000001,y=0.0000000001}, -- dummy
-		[BZ["Alterac Valley"]] = {x=0.00025277584791183,y=0.0003791834626879}, -- Alterac Valley
-		[BZ["Arathi Basin"]] = {x=0.00060996413230886,y=0.00091460134301867}, -- Arathi Basin
-		[BZ["Warsong Gulch"]] = {x=0.000934666820934484,y=0.0013986080884933}, -- Warsong Gulch
-	},
-
-	[1] = { -- Kalimdor
-		[0] = {x = 24533.025279205, y = 36800.210572494}, -- No local Map
-		[1] = {x=0.00018538534641226,y=0.00027837923594884}, -- Ashenvale
-		[2] = {x=0.0002110515322004,y=0.00031666883400508}, -- Aszhara
-		[3] = {x=0.00016346999577114,y=0.0002448782324791}, -- Darkshore
-		[4] = {x=0.001011919762407,y=0.0015176417572158}, -- Darnassus
-		[5] = {x=0.000238049243117769,y=0.00035701000264713}, -- Desolace
-		[6] = {x=0.000202241752828887,y=0.00030311250260898},  -- Durotar
-		[7] = {x=0.00020404585770198,y=0.00030594425542014}, -- Dustwallow Marsh
-		[8] = {x=0.00018605589866638,y=0.00027919347797121}, -- Felwood
-		[9] = {x=0.00015413335391453,y=0.00023112978254046}, -- Feralas
-		[10] = {x=0.00046338992459433,y=0.00069469745670046}, -- Moonglade
-		[11] = {x=0.00020824585642133,y=0.00031234536852155}, -- Mulgore
-		[12] = {x=0.00076302673135485,y=0.0011450946331024}, -- Orgrimmar
-		[13] = {x=0.00030702139650072,y=0.00046115900788988}, -- Silithus
-		[14] = {x=0.0002192035317421,y=0.00032897400004523}, -- Stonetalon Mountains
-		[15] = {x=0.00015519559383392,y=0.00023255497217178}, -- Tanaris
-		[16] = {x=0.00021010743720191,y=0.00031522342136928}, -- Teldrassil
-		[17] = {x=0.0001055257661002,y=0.00015825512153762}, -- Barrens
-		[18] = {x=0.00024301665169852,y=0.00036516572747912}, -- Thousand Needles
-		[19] = {x=0.00102553303755263,y=0.0015390366315842}, -- Thunderbluff
-		[20] = {x=0.00028926772730691,y=0.0004336131470544}, -- Un'Goro Crater
-		[21] = {x=0.0001503484589713,y=0.0002260080405644}, -- Winterspring
-	},
-
-	[2] = { -- Eastern Kingdoms
-		[0] = {x = 27149.795290881, y = 40741.175327834}, -- No local Map
-		[1] = {x=0.00038236060312816,y=0.00057270910058703}, -- Alterac Mountains
-		[2] = {x=0.00029711957488741,y=0.00044587893145425}, -- Arathi Highlands
-		[3] = {x=0.00043004538331713,y=0.00064518196242196}, -- Badlands
-		[4] = {x=0.00031955327306475,y=0.00047930649348668}, -- Blasted Lands
-		[5] = {x=0.00036544565643583,y=0.00054845426763807}, -- Burning Steppes
-		[6] = {x=0.00042719074657985,y=0.00064268921102796}, -- Deadwind Pass
-		[7] = {x=0.00021748670509883,y=0.00032613213573183}, -- Dun Morogh
-		[8] = {x=0.00039665134889739,y=0.000594192317755393},-- Duskwood
-		[9] = {x=0.00027669753347124,y=0.00041501436914716}, -- Eastern Plaguelands
-		[10] = {x=0.00030816452843802,y=0.00046261719294957}, -- Elwynn Forest
-		[11] = {x=0.00033472904137203,y=0.00050214784485953}, -- Hillsbrad Foothills
-		[12] = {x=0.0013541845338685,y=0.0020301469734737}, -- Ironforge
-		[13] = {x=0.00038827742849077,y=0.000582420040021079}, -- Loch Modan
-		[14] = {x=0.00049317521708352,y=0.0007399320602417}, -- Redridge Mountains
-		[15] = {x=0.00047916280371802,y=0.00071918751512255}, -- Searing Gorge
-		[16] = {x=0.00025506743362975,y=0.00038200191089085}, -- Silverpine
-		[17] = {x=0.00079576990434102,y=0.0011931381055287}, -- Stormwind
-		[18] = {x=0.00016783603600093,y=0.00025128040994917}, -- Stranglethorn
-		[19] = {x=0.00046689595494952,y=0.00070027368409293}, -- Swamp of Sorrows
-		[20] = {x=0.0002777065549578,y=0.00041729531117848}, -- Hinterlands
-		[21] = {x=0.00023638989244189,y=0.0003550010068076}, -- Tirisfal
-		[22] = {x=0.0011167100497655,y=0.0016737942184721}, -- Undercity
-		[23] = {x=0.00024908781051636,y=0.00037342309951782}, -- Western Plaguelands
-		[24] = {x=0.00030591232436044,y=0.00045816733368805},-- Westfall
-		[25] = {x=0.00025879591703415,y=0.00038863212934562}, -- Wetlands
-	}
-}
-
-local ZonemapzhCN = {
-	[1] = {
-		[0] = 0,
-		[1] = 21,
-		[2] = 5,
-		[3] = 18,
-		[4] = 15,
-		[5] = 12,
-		[6] = 20,
-		[7] = 7,
-		[8] = 13,
-		[9] = 10,
-		[10] = 6,
-		[11] = 16,
-		[12] = 1,
-		[13] = 14,
-		[14] = 2,
-		[15] = 11,
-		[16] = 9,
-		[17] = 17,
-		[18] = 8,
-		[19] = 4,
-		[20] = 20,
-		[21] = 3,
-	},
-	[2] = {
-		[0] = 0,
-		[1] = 9,
-		[2] = 7,
-		[3] = 1,
-		[4] = 11,
-		[5] = 22,
-		[6] = 19,
-		[7] = 21,
-		[8] = 8,
-		[9] = 17,
-		[10] = 13,
-		[11] = 25,
-		[12] = 15,
-		[13] = 5,
-		[14] = 10,
-		[15] = 18,
-		[16] = 3,
-		[17] = 23,
-		[18] = 24,
-		[19] = 4,
-		[20] = 14,
-		[21] = 20,
-		[22] = 6,
-		[23] = 12,
-		[24] = 16,
-		[25] = 2,
-	},
-}
 
 local HealSpells = {
     ["DRUID"] = {
@@ -240,31 +117,19 @@ local function OnUpdate()
 	Range:FullUpdate(this:GetParent())
 end
 
-local function OnEvent()
-	if event == "ZONE_CHANGED_NEW_AREA" or not event then
-		SetMapToCurrentZone()
-		Continent = GetCurrentMapContinent()
-		Zone = GetCurrentMapZone()
-		if GetLocale() == "zhCN" and Continent > 0 then
-			Zone = ZonemapzhCN[Continent][Zone]
-		end
-		ZoneName = GetZoneText()
-		if ZoneName == BZ["Warsong Gulch"] or ZoneName == BZ["Arathi Basin"] or ZoneName == BZ["Alterac Valley"] then
-			Zone = ZoneName
-		end
-	elseif LunaUF.db.profile.RangeCLparsing and events[event] then
-		ParseCombatMessage(events[event], arg1)
-	end
-end
-
-OnEvent()
-ZoneWatch:SetScript("OnEvent", OnEvent)
-ZoneWatch:RegisterEvent("ZONE_CHANGED_NEW_AREA")
-for i in pairs(events) do ZoneWatch:RegisterEvent(i) end
-
 function Range:GetRange(UnitID)
     if UnitExists(UnitID) and UnitIsVisible(UnitID) then
-		local _,instance = IsInInstance()
+
+		-- try to read distance via superwow first
+		if LunaUF.isSuperWoW then
+			local x1, y1, z1 = UnitPosition("player")
+			local x2, y2, z2 = UnitPosition(UnitID)
+			-- only continue if we got position values
+			if x1 and y1 and z1 and x2 and y2 and z2 then
+				local distance = ((x2 - x1)^2 + (y2 - y1)^2 + (z2 - z1)^2)^.5
+				return distance < 45 and distance or 45
+			end
+		end
 
 		if CheckInteractDistance(UnitID, 1) then
 			return 10
@@ -272,22 +137,6 @@ function Range:GetRange(UnitID)
 			return 10
 		elseif CheckInteractDistance(UnitID, 4) then
 			return 30
-		elseif (instance == "none" or instance == "pvp") and not WorldMapFrame:IsVisible() then
-			local px, py, ux, uy, distance
-			SetMapToCurrentZone()
-			px, py = GetPlayerMapPosition("player")
-			ux, uy = GetPlayerMapPosition(UnitID)
-			if Zone ~= 0 and Continent ~= 0 then
-				distance = sqrt(((px - ux)/MapScales[Continent][Zone].x)^2 + ((py - uy)/MapScales[Continent][Zone].y)^2)
-			else
-				local xDelta, yDelta;
-				px, py = px*MapScales[Continent][Zone].x, py*MapScales[Continent][Zone].y
-				ux, uy = ux*MapScales[Continent][Zone].x, uy*MapScales[Continent][Zone].y
-				xDelta = (ux - px)
-				yDelta = (uy - py)
-				distance = sqrt(xDelta*xDelta + yDelta*yDelta)
-			end
-			return distance
 		elseif (GetTime() - (roster[UnitID] or 0)) < 4 then
 			return 40
 		else
@@ -425,9 +274,11 @@ function Range:FullUpdate(frame)
 
 end
 
-if HealSpells[playerClass] then -- only hook on healing classes
-	Range:Hook("CastSpell")
-	Range:Hook("CastSpellByName")
-	Range:Hook("UseAction")
-	Range:Hook("SpellStopTargeting")
+if not LunaUF.isSuperWoW then
+	if HealSpells[playerClass] then -- only hook on healing classes
+		Range:Hook("CastSpell")
+		Range:Hook("CastSpellByName")
+		Range:Hook("UseAction")
+		Range:Hook("SpellStopTargeting")
+	end
 end


### PR DESCRIPTION
- Update readme.md
- Babble-Zone: Add TurtleWow zone names to prevent lua errors
- Update Luna version
- Add superwow version if loaded to luna config
range.lua
 - remove zone distance lookup (incompatible with turtlewow)
 - add superwow distance check
cast.lua
 - uses SuperWoW events for castbars that allows for proper castbars per unique unit
 - force end cast bars when event comes in for existing casts that have finished