### PR TITLE
dynamic load libclassicdurations

### DIFF
--- a/LunaUnitFrames-BCC.toc
+++ b/LunaUnitFrames-BCC.toc
@@ -24,7 +24,6 @@ libs\LibHealComm-4.0\LibHealComm-4.0.xml
 libs\LibAuraTypes\LibAuraTypes.lua
 libs\LibSpellLocks\LibSpellLocks.lua
 libs\LibTargeted\LibTargeted.lua
-libs\LibClassicDurations\LibClassicDurations.xml
 
 # oUF
 libs\oUF\init.lua

--- a/libs/oUF/init.lua
+++ b/libs/oUF/init.lua
@@ -6,7 +6,7 @@ ns.oUF.isClassic = WOW_PROJECT_ID == (WOW_PROJECT_CLASSIC or 2)
 ns.oUF.isTBC = WOW_PROJECT_ID == (WOW_PROJECT_BURNING_CRUSADE_CLASSIC or 5)
 
 if(ns.oUF.isClassic and LE_EXPANSION_LEVEL_CURRENT == LE_EXPANSION_BURNING_CRUSADE) then
-    -- TBC 2026 appears to use Classic project ID with BC expansion
+    -- TBC 2026 beta appears to use Classic project ID with BC expansion
     ns.oUF.isClassic =  false
     ns.oUF.isTBC = true
 end
@@ -14,3 +14,16 @@ end
 ns.oUF.isClassicSoD = ns.oUF.isClassic and C_Seasons.HasActiveSeason() and (C_Seasons.GetActiveSeason() == Enum.SeasonID.SeasonOfDiscovery)
 ns.oUF.isWrath = WOW_PROJECT_ID == (WOW_PROJECT_WRATH_CLASSIC or 11)
 ns.oUF.isRetail = WOW_PROJECT_ID == (WOW_PROJECT_MAINLINE or 1)
+
+--LCD is only available for classic
+local LCD = LibStub and LibStub("LibClassicDurations", true)
+
+if LCD and LCD.UnitAura then
+    -- 1. Use LibClassicDurations
+    ns.oUF.LCDUnitAura = function(unit, index, filter)
+        return LCD:UnitAura(unit, index, filter)
+    end
+else
+    -- 2. Use native UnitAura
+    ns.oUF.LCDUnitAura = _G.UnitAura
+end

--- a/libs/oUF_Plugins/oUF_RaidStatusIndicators/oUF_RaidStatusIndicators.lua
+++ b/libs/oUF_Plugins/oUF_RaidStatusIndicators/oUF_RaidStatusIndicators.lua
@@ -39,7 +39,6 @@ RaidStatusIndicators - A `table` containing frames with a .texture to show the s
 local _, ns = ...
 local oUF = ns.oUF
 
-local lCD = LibStub("LibClassicDurations")
 local Vex = LibStub("LibVexation-1.0")
 
 local playerClass = select(2, UnitClass("player"))
@@ -63,7 +62,7 @@ local function checkDispel(unit, index)
 	while name do
 		if canCure[debuffType] then
 			if found_index == index then
-				return lCD:UnitAura(unit, i, "HARMFUL")
+				return oUF.UnitAura(unit, i, "HARMFUL")
 			end
 			found_index = found_index + 1
 		end
@@ -126,7 +125,7 @@ local function checkAura(unit, spells, playeronly)
 			local i, casterunit,_,_,spellID = 1, select(7,UnitAura(unit, 1))
 			while spellID do
 				if spellID == tonumber(spell) and (not playeronly or playeronly and casterunit and UnitIsUnit(casterunit,"player")) then
-					return lCD:UnitAura(unit, i)
+					return oUF.LCDUnitAura(unit, i)
 				end
 				i = i + 1
 				casterunit,_,_,spellID = select(7, UnitAura(unit, i))
@@ -134,7 +133,7 @@ local function checkAura(unit, spells, playeronly)
 			i, casterunit,_,_,spellID = 1, select(7,UnitAura(unit, 1, "HARMFUL"))
 			while spellID do
 				if spellID == tonumber(spell) and (not playeronly or playeronly and casterunit and UnitIsUnit(casterunit,"player")) then
-					return lCD:UnitAura(unit, i, "HARMFUL")
+					return oUF.LCDUnitAura(unit, i, "HARMFUL")
 				end
 				i = i + 1
 				casterunit,_,_,spellID = select(7, UnitAura(unit, i, "HARMFUL"))
@@ -145,7 +144,7 @@ local function checkAura(unit, spells, playeronly)
 			local lowerSpell = strlower(spell)
 			while spellName do
 				if strmatch(strlower(spellName),lowerSpell) and (not playeronly or playeronly and casterunit and UnitIsUnit(casterunit,"player")) then
-					return lCD:UnitAura(unit, i)
+					return oUF.LCDUnitAura(unit, i)
 				end
 				i = i + 1
 				spellName = UnitAura(unit, i)
@@ -155,7 +154,7 @@ local function checkAura(unit, spells, playeronly)
 			casterunit = select(7,UnitAura(unit, 1, "HARMFUL"))
 			while spellName do
 				if strmatch(strlower(spellName),lowerSpell) and (not playeronly or playeronly and casterunit and UnitIsUnit(casterunit,"player")) then
-					return lCD:UnitAura(unit, i, "HARMFUL")
+					return oUF.LCDUnitAura(unit, i, "HARMFUL")
 				end
 				i = i + 1
 				spellName = UnitAura(unit, i, "HARMFUL")

--- a/libs/oUF_Plugins/oUF_SimpleAuras/oUF_SimpleAuras.lua
+++ b/libs/oUF_Plugins/oUF_SimpleAuras/oUF_SimpleAuras.lua
@@ -69,7 +69,9 @@ local _, ns = ...
 local oUF = ns.oUF
 
 local LCD = LibStub("LibClassicDurations", true)
-LCD:Register("LunaUnitFrames")
+if LCD then
+	LCD:Register("LunaUnitFrames")
+end
 local weaponWatchTimer
 local mainHandEnd, mainHandDuration, mainHandCharges, offHandEnd, offHandDuration, offHandCharges
 
@@ -142,8 +144,9 @@ end
 
 
 local function CheckBlizzardCooldownTextOverflow(element, button)
-	--OmniCC always prevents blizzard timers so we dont need to do this if its installed
-    if element.disableBCC or _G.OmniCC then return end
+	--OmniCC always prevents blizzard timers so we dont need to do
+	-- this if it's installed and not disabled
+    if element.disableBCC or (_G.OmniCC and not element.disableOCC) then return end
 
 	if not button.cdFontString then
 		-- Cache the cooldown text font string
@@ -158,8 +161,8 @@ local function CheckBlizzardCooldownTextOverflow(element, button)
 	local fs = button.cdFontString
 
 	local _, oldFontSize, _ = fs:GetFont()
-    local button_width = button:GetWidth()
-	local fontSize = math.max(8, button_width * 0.42)
+	local button_width = button:GetWidth()
+	local fontSize = math.max(8, button_width^0.95 * 0.42)
 
 	if(oldFontSize ~= fontSize) then
 		--only update when font size changed
@@ -169,7 +172,7 @@ local function CheckBlizzardCooldownTextOverflow(element, button)
 
 	local text_width = fs:GetStringWidth()
 
-    if (button_width < 18)  then
+    if (button_width < 18.5)  then
         button.cd:SetHideCountdownNumbers(true)
     else
         button.cd:SetHideCountdownNumbers(false)
@@ -435,7 +438,7 @@ local function UpdateAuras(self, event, unit)
 		local button
 		if element.buffs then
 			for i=1,(element.maxBuffs or 32) do
-				local name, _, _, _, _, _, caster = LCD:UnitAura(self.unit, i, filter)
+				local name, _, _, _, _, _, caster = oUF.LCDUnitAura(self.unit, i, filter)
 				if name or element.forceShow then
 					if element.buffFilter ~= 2 or caster == "player" then
 						updateIcon(element, self.unit, i, currentSlot, filter, false)
@@ -467,7 +470,7 @@ local function UpdateAuras(self, event, unit)
 		filter = "HARMFUL"..(element.debuffFilter == 3 and "|RAID" or "")
 		if element.debuffs then
 			for i=1,(element.maxDebuffs or 40) do
-				local name, _, _, _, _, _, caster = LCD:UnitAura(self.unit, i, filter)
+				local name, _, _, _, _, _, caster = oUF.LCDUnitAura(self.unit, i, filter)
 				if name or element.forceShow then
 					if element.debuffFilter ~= 2 or caster == "player" then
 						updateIcon(element, self.unit, i, currentSlot, filter, true)
@@ -904,9 +907,11 @@ local function Enable(self)
 			self:RegisterEvent("UNIT_INVENTORY_CHANGED", SetWeaponUpdateTimer)
 			UpdateWeaponEnchants(self, true)
 		elseif self.unit ~= "player" then
-			LCD.RegisterCallback("LUF", "UNIT_BUFF", function(event, unit)
-				UpdateAuras(element, "UNIT_AURA", unit)
-			end)
+			if LCD and LCD.RegisterCallback then
+				LCD:RegisterCallback("LUF", "UNIT_BUFF", function(event, unit)
+					UpdateAuras(element, "UNIT_AURA", unit)
+				end)
+			end
 		end
 
 		element.buffFrame = element.buffFrame or CreateFrame("Frame", "$parentBuffFrame", element)

--- a/libs/oUF_Plugins/oUF_StatusPortrait/oUF_StatusPortrait.lua
+++ b/libs/oUF_Plugins/oUF_StatusPortrait/oUF_StatusPortrait.lua
@@ -39,7 +39,6 @@ the unit.
 local _, ns = ...
 local oUF = ns.oUF
 
-local lCD = LibStub("LibClassicDurations")
 local LAT = LibStub("LibAuraTypes")
 local SL = LibStub("LibSpellLocks")
 
@@ -79,7 +78,7 @@ local function Update(self, event, unit)
 		icon, duration, expirationTime = select(3,SL:GetSpellLockInfo(unit))
 		if not icon then
 			for i=1, 32 do
-				local name, tmpicon, _, _, tmpduration, tmpexpirationTime, _, _, _, spellId = lCD:UnitAura(unit, i, "HELPFUL")
+				local name, tmpicon, _, _, tmpduration, tmpexpirationTime, _, _, _, spellId = oUF.LCDUnitAura(unit, i, "HELPFUL")
 				if not name then break end
 				local prio = LAT.GetAuraInfo(spellId, UnitCanAttack("player",unit))
 				if prio and prio > maxPrio and prio >= PRIO_SILENCE then
@@ -90,7 +89,7 @@ local function Update(self, event, unit)
 				end
 			end
 			for i=1, 16 do
-				local name, tmpicon, _, _, tmpduration, tmpexpirationTime, _, _, _, spellId = lCD:UnitAura(unit, i, "HARMFUL")
+				local name, tmpicon, _, _, tmpduration, tmpexpirationTime, _, _, _, spellId = oUF.LCDUnitAura(unit, i, "HARMFUL")
 				if not name then break end
 				local prio = LAT.GetAuraInfo(spellId, UnitCanAttack("player",unit))
 				if prio and prio > maxPrio and prio >= PRIO_SILENCE then


### PR DESCRIPTION
- Load libclassicdurations only in classic and not tbc
- Fix resizing of aura durations when omniCC installed and disabled in luna options