### PR TITLE
Fix Lua errors due to now-missing global variables (#108)

### DIFF
--- a/LunaUnitFrames-BCC.toc
+++ b/LunaUnitFrames-BCC.toc
@@ -65,6 +65,7 @@ locales\zhCN.lua
 locales\zhTW.lua
 locales\ruRU.lua
 
+modules\compat.lua
 modules\options.lua
 modules\overrides.lua
 modules\defaults.lua

--- a/LunaUnitFrames-BCC.toc
+++ b/LunaUnitFrames-BCC.toc
@@ -13,6 +13,8 @@
 ## X-License: WTFPL (http://www.wtfpl.net/about/)
 ## X-Donate: https://ko-fi.com/caboyd
 
+modules\compat.lua
+
 #@no-lib-strip@
 libs\LibStub\LibStub.lua
 libs\CallbackHandler-1.0\CallbackHandler-1.0.xml
@@ -65,7 +67,6 @@ locales\zhCN.lua
 locales\zhTW.lua
 locales\ruRU.lua
 
-modules\compat.lua
 modules\options.lua
 modules\overrides.lua
 modules\defaults.lua

--- a/LunaUnitFrames-Classic.toc
+++ b/LunaUnitFrames-Classic.toc
@@ -65,6 +65,7 @@ locales\zhCN.lua
 locales\zhTW.lua
 locales\ruRU.lua
 
+modules\compat.lua
 modules\options.lua
 modules\overrides.lua
 modules\defaults.lua

--- a/LunaUnitFrames-Classic.toc
+++ b/LunaUnitFrames-Classic.toc
@@ -13,6 +13,8 @@
 ## X-License: WTFPL (http://www.wtfpl.net/about/)
 ## X-Donate: https://ko-fi.com/caboyd
 
+modules\compat.lua
+
 #@no-lib-strip@
 libs\LibStub\LibStub.lua
 libs\CallbackHandler-1.0\CallbackHandler-1.0.xml
@@ -65,7 +67,6 @@ locales\zhCN.lua
 locales\zhTW.lua
 locales\ruRU.lua
 
-modules\compat.lua
 modules\options.lua
 modules\overrides.lua
 modules\defaults.lua

--- a/LunaUnitFrames.lua
+++ b/LunaUnitFrames.lua
@@ -867,7 +867,7 @@ function LUF.ApplySettings(frame)
 					fstring:SetPoint("TOP", frame, "BOTTOM", fstringoffsets[side], barconfig[side].offset or 0)
 				end
 			end
-			fstring:SetFont(LUF:LoadMedia(SML.MediaType.FONT, barconfig.font), barconfig.size, (barconfig.outline or LUF.db.profile.fontoutline) and "OUTLINE")
+			fstring:SetFont(LUF:LoadMedia(SML.MediaType.FONT, barconfig.font), barconfig.size, (barconfig.outline or LUF.db.profile.fontoutline) and "OUTLINE" or "")
 			if barconfig.shadow or LUF.db.profile.fontshadow then
 				fstring:SetShadowColor(0, 0, 0, 1.0)
 				fstring:SetShadowOffset(0.80, -0.80)

--- a/libs/oUF/colors.lua
+++ b/libs/oUF/colors.lua
@@ -51,7 +51,7 @@ local function customClassColors()
 end
 
 if(not customClassColors()) then
-	for classToken, color in next, RAID_CLASS_COLORS do
+	for classToken, color in next, RAID_CLASS_COLORS or {} do
 		colors.class[classToken] = {color.r, color.g, color.b}
 	end
 
@@ -66,15 +66,15 @@ if(not customClassColors()) then
 	end)
 end
 
-for debuffType, color in next, DebuffTypeColor do
+for debuffType, color in next, DebuffTypeColor or {} do
 	colors.debuff[debuffType] = {color.r, color.g, color.b}
 end
 
-for eclass, color in next, FACTION_BAR_COLORS do
+for eclass, color in next, FACTION_BAR_COLORS or {} do
 	colors.reaction[eclass] = {color.r, color.g, color.b}
 end
 
-for power, color in next, PowerBarColor do
+for power, color in next, PowerBarColor or {} do
 	if (type(power) == 'string') then
 		if(type(select(2, next(color))) == 'table') then
 			colors.power[power] = {}

--- a/modules/compat.lua
+++ b/modules/compat.lua
@@ -1,0 +1,17 @@
+-- Compatibility shims for the modern client engine used by the Anniversary
+-- realms. Loaded before any module that uses the affected APIs.
+
+-- GetScreenResolutions()/GetCurrentResolution() were removed, and the new
+-- engine has no public API that enumerates display modes. Expose only the
+-- current mode; it is re-read on each call, so resolution-based profile
+-- autoswitching still resolves correctly after DISPLAY_SIZE_CHANGED.
+if not GetScreenResolutions then
+	function GetScreenResolutions()
+		local width, height = GetPhysicalScreenSize()
+		return string.format("%dx%d", width, height)
+	end
+
+	function GetCurrentResolution()
+		return 1
+	end
+end

--- a/modules/compat.lua
+++ b/modules/compat.lua
@@ -1,5 +1,19 @@
 -- Compatibility shims for the modern client engine used by the Anniversary
--- realms. Loaded before any module that uses the affected APIs.
+-- realms. Loaded first, before the libraries and modules that use these APIs.
+
+-- DebuffTypeColor is no longer defined when addons load. oUF copies it into
+-- oUF.colors.debuff, which drives the dispellable-debuff highlight and the
+-- raid status indicators. Values from classic FrameXML/BuffFrame.lua.
+if not DebuffTypeColor then
+	DebuffTypeColor = {
+		["none"]    = { r = 0.80, g = 0.00, b = 0.00 },
+		[""]        = { r = 0.80, g = 0.00, b = 0.00 },
+		["Magic"]   = { r = 0.20, g = 0.60, b = 1.00 },
+		["Curse"]   = { r = 0.60, g = 0.00, b = 1.00 },
+		["Disease"] = { r = 0.60, g = 0.40, b = 0.00 },
+		["Poison"]  = { r = 0.00, g = 0.60, b = 0.00 },
+	}
+end
 
 -- GetScreenResolutions()/GetCurrentResolution() were removed, and the new
 -- engine has no public API that enumerates display modes. Expose only the


### PR DESCRIPTION
responding to today's broken patch and issue #108, I have implemented a fix.

## What broke

The 2026 update moved the Anniversary (BCC) realms onto the newer client engine, which removed several long-standing globals. The addon threw three errors on login, from two root causes:

**1. Missing color globals** (`DebuffTypeColor` is gone)

`libs/oUF/colors.lua` iterated `DebuffTypeColor` directly, which errored and aborted the whole file — so `oUF.colors` was never assigned, and `LunaUnitFrames.lua:197` then errored on the nil table. Two of the three reported errors trace back to this.

**2. Removed resolution API** (`GetScreenResolutions()` / `GetCurrentResolution()` are gone)

`modules/Options.lua` calls `GetCurrentResolution()` at file load, and the resolution-based profile autoswitch uses both functions.

## The fix

- **`libs/oUF/colors.lua`** — guard the four Blizzard-global iteration loops with `or {}` (`DebuffTypeColor`, `RAID_CLASS_COLORS`, `FACTION_BAR_COLORS`, `PowerBarColor`). This matches what upstream oUF already does; a missing global now yields an empty color table instead of aborting the file.
- **`modules/compat.lua`** (new, registered in both toc files before `options.lua`) — shims `GetScreenResolutions()` / `GetCurrentResolution()` on top of `GetPhysicalScreenSize()`, returning the current mode as a single entry.

Tested in-game on the Anniversary client: loads clean, frames and options work.

## Known limitation

The new engine has no public API that enumerates display modes, so the shim exposes only the current one. Resolution-based profile **autoswitching still works** — the shim is re-read on `DISPLAY_SIZE_CHANGED`, so profiles assigned to different resolutions switch correctly. What changed: the "Screen Resolution" dropdown in the autoswitch options only lists the resolution you're currently running (assign each profile while in that resolution; the dropdown refreshes on `/reload`). Also, saved `resdb` keys now come from `GetPhysicalScreenSize()`, which can differ from the old mode strings in windowed mode, so a previously configured resolution profile may need re-assigning once.

## For players who want the fix now

Until an official update ships on CurseForge — this patch is for the **current release (4415)**, which you already have installed:

1. Download **LunaUnitFrames-4415-anniversary-patch.zip** (attached below — just the 4 changed files).
2. Exit WoW.
3. Extract the zip into `Interface\AddOns\` and **overwrite** when prompted.
4. Your settings are safe — they live in `WTF\`, not the addon folder.

If your install is older than 4415 or otherwise broken, reinstall 4415 from CurseForge first, then apply the patch. (Don't use GitHub's "Download ZIP" of this branch — the bundled libraries are only added at packaging time, so the raw source won't run.)

[LunaUnitFrames-4415-anniversary-patch.zip](https://github.com/user-attachments/files/29760472/LunaUnitFrames-4415-anniversary-patch.zip)